### PR TITLE
Add functionality for multiple repos - fix for 8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ means. High quality open source software like Proxmox needs our support!
 
 ### News:
 
-Last updated for: pve-manager/6.4-4/337d6701 (running kernel: 5.4.106-1-pve)
+Last updated for: pve-manager/8.0.4/d258a813cfa6b390 (running kernel: 8.0.4)
 
 ### How does it work?
 

--- a/pve-nag-buster.sh
+++ b/pve-nag-buster.sh
@@ -32,10 +32,17 @@ if grep -qs "$NAGTOKEN" "$NAGFILE" > /dev/null 2>&1; then
 fi
 
 # disable paid repo list
+disable_repo() {
+    local REPO_BASE="$1"
 
-PAID_BASE="/etc/apt/sources.list.d/pve-enterprise"
+    if [ -f "$REPO_BASE.list" ]; then
+        echo "Disabling $REPO_BASE repo list ..."
+        mv -f "$REPO_BASE.list" "$REPO_BASE.disabled"
+    fi
+}
 
-if [ -f "$PAID_BASE.list" ]; then
-  echo "$SCRIPT: Disabling PVE paid repo list ..."
-  mv -f "$PAID_BASE.list" "$PAID_BASE.disabled"
-fi
+# Disable pve-enterprise repo
+disable_repo "/etc/apt/sources.list.d/pve-enterprise"
+
+# Disable ceph repo
+disable_repo "/etc/apt/sources.list.d/ceph"


### PR DESCRIPTION
I've added a new function disable_repo() that allows you to pass a repository in to disable. It will change the repository to "$REPO_BASE.disabled"

This should allow for multiple repositories to be disabled, which fixes the release for 8.0. They added a new enterprise repo in ceph.list.

Thanks!
G