### PR TITLE
Add compatibility for version 8.2 and a restoration script for peace of mind

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ means. High quality open source software like Proxmox needs our support!
 
 ### News:
 
-Last updated for: pve-manager/6.4-4/337d6701 (running kernel: 5.4.106-1-pve)
+Last updated for: pve-manager/8.2.2/9355359cd7afbae4 (running kernel: 6.8.4-2-pve)
 
 ### How does it work?
 
@@ -46,6 +46,11 @@ cd pve-nag-buster && sudo ./install.sh
 ```sh
 sudo ./install.sh --uninstall
 # remove /etc/apt/sources.list.d/pve-no-subscription.list if desired
+```
+
+### Restore Defaults:
+```sh
+sudo ./install.sh --restore_defaults
 ```
 
 ### Notes:

--- a/install.sh
+++ b/install.sh
@@ -43,10 +43,9 @@ _main() {
       _uninstall
       ;;
     "--restore_defaults")
-      # restore default, also uninstalls, requires root
+      # restore defaults, requires root
       assert_root
       _restore
-      _uninstall
       ;;
     "--install" | "--offline" | "")
       # install dpkg hooks, requires root
@@ -67,6 +66,8 @@ _uninstall() {
     rm -f "/etc/apt/apt.conf.d/86pve-nags"
   [ -f "/usr/share/pve-nag-buster.sh" ] &&
     rm -f "/usr/share/pve-nag-buster.sh"
+  [ -f "/usr/share/pve-nag-restore.sh" ] &&
+    rm -f "/usr/share/pve-nag-restore.sh"
 
   echo "Script and dpkg hooks removed, please manually remove /etc/apt/sources.list.d/pve-no-subscription.list if desired"
 }
@@ -77,7 +78,9 @@ _restore() {
   [ -f "/etc/apt/sources.list.d/pve-no-subscription.list" ] &&
     rm -f "/etc/apt/sources.list.d/pve-no-subscription.list"
 
-  # the dpkg pre/post install hooks will be removed by _uninstall()
+  # remove dpkg pre/post install hooks 
+  [ -f "/etc/apt/apt.conf.d/86pve-nags" ] &&
+    rm -f "/etc/apt/apt.conf.d/86pve-nags"
 
   # install the restoration script if available
   temp=''

--- a/install.sh
+++ b/install.sh
@@ -42,6 +42,12 @@ _main() {
       assert_root
       _uninstall
       ;;
+    "--restore_defaults")
+      # restore default, also uninstalls, requires root
+      assert_root
+      _restore
+      _uninstall
+      ;;
     "--install" | "--offline" | "")
       # install dpkg hooks, requires root
       assert_root
@@ -63,6 +69,40 @@ _uninstall() {
     rm -f "/usr/share/pve-nag-buster.sh"
 
   echo "Script and dpkg hooks removed, please manually remove /etc/apt/sources.list.d/pve-no-subscription.list if desired"
+}
+
+_restore() {
+  # remove the pve-no-subscription list
+  echo "Removing PVE no-subscription repo list ..."
+  [ -f "/etc/apt/sources.list.d/pve-no-subscription.list" ] &&
+    rm -f "/etc/apt/sources.list.d/pve-no-subscription.list"
+
+  # the dpkg pre/post install hooks will be removed by _uninstall()
+
+  # install the restoration script if available
+  temp=''
+  if [ -f "pve-nag-restore.sh" ]; then
+    # local copy available
+    temp="pve-nag-restore.sh"
+  elif [ "$1" != "--offline" ]; then
+    # fetch from github
+    echo "Fetching hook script from GitHub ..."
+    tempd="$(mktemp -d)" &&
+      trap "echo 'Cleaning up temporary files ...'; rm -f $tempd/*; rmdir $tempd" EXIT
+    temp="$tempd/pve-nag-restore.sh"
+    wget https://raw.githubusercontent.com/foundObjects/pve-nag-buster/master/pve-nag-restore.sh \
+      -q --show-progress -O "$temp"
+  else
+    echo "No hook script available for offline restoration"
+    exit 1
+  fi
+  echo "Installing hook script as /usr/share/pve-nag-restore.sh"
+  install -o root -m 0550 "$temp" "/usr/share/pve-nag-restore.sh"
+
+  echo "Running restoration script"
+  /usr/share/pve-nag-restore.sh
+
+  return 0
 }
 
 _install() {

--- a/pve-nag-buster.sh
+++ b/pve-nag-buster.sh
@@ -39,3 +39,12 @@ if [ -f "$PAID_BASE.list" ]; then
   echo "$SCRIPT: Disabling PVE paid repo list ..."
   mv -f "$PAID_BASE.list" "$PAID_BASE.disabled"
 fi
+
+# disable paid ceph repo list if it exists
+
+CEPH_PAID_BASE="/etc/apt/sources.list.d/ceph"
+
+if [  -f "$CEPH_PAID_BASE.list" ]; then
+    echo "$SCRIPT: Disabling ceph paid repo list ..."
+  mv -f "$CEPH_PAID_BASE.list" "$CEPH_PAID_BASE.disabled"
+fi

--- a/pve-nag-restore.sh
+++ b/pve-nag-restore.sh
@@ -24,7 +24,7 @@ SCRIPT="$(basename "$0")"
 
 # enable license nag: https://johnscs.com/remove-proxmox51-subscription-notice/
 
-if grep -qs "$NAGTOKEN" "$NAGFILE" > /dev/null 2>&1; then
+if [ -f "$NAGFILE.orig" ]; then
   echo "$SCRIPT: Restoring Nag ..."
   mv -f "$NAGFILE.orig" "$NAGFILE"
   rm -f "$NAGFILE.orig"

--- a/pve-nag-restore.sh
+++ b/pve-nag-restore.sh
@@ -1,0 +1,50 @@
+#!/bin/sh
+#
+# pve-nag-restore.sh https://github.com/foundObjects/pve-nag-buster
+#
+# Restores Proxmox VE 6.x+ license nags
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+NAGTOKEN="data.status.toLowerCase() !== 'active'"
+NAGFILE="/usr/share/javascript/proxmox-widget-toolkit/proxmoxlib.js"
+SCRIPT="$(basename "$0")"
+
+# enable license nag: https://johnscs.com/remove-proxmox51-subscription-notice/
+
+if grep -qs "$NAGTOKEN" "$NAGFILE" > /dev/null 2>&1; then
+  echo "$SCRIPT: Restoring Nag ..."
+  mv -f "$NAGFILE.orig" "$NAGFILE"
+  rm -f "$NAGFILE.orig"
+  systemctl restart pveproxy.service
+fi
+
+# enable paid repo list
+
+PAID_BASE="/etc/apt/sources.list.d/pve-enterprise"
+
+if [ -f "$PAID_BASE.disabled" ]; then
+  echo "$SCRIPT: Enabling PVE paid repo list ..."
+  mv -f "$PAID_BASE.disabled" "$PAID_BASE.list"
+fi
+
+# enable paid ceph repo list if it exists
+
+CEPH_PAID_BASE="/etc/apt/sources.list.d/ceph"
+
+if [  -f "$CEPH_PAID_BASE.disabled" ]; then
+    echo "$SCRIPT: Enabling ceph paid repo list ..."
+  mv -f "$CEPH_PAID_BASE.disabled" "$CEPH_PAID_BASE.list"
+fi


### PR DESCRIPTION
I added a bit to the buster script to disable the ceph repository. Then I was also interested in having the ability to reverse the changes made so I made a restore script. I understand if that feature would not be desired but I wanted to automate the restoration process.